### PR TITLE
New Rule: Format newlines before opening braces

### DIFF
--- a/Swimat.xcodeproj/project.pbxproj
+++ b/Swimat.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		2FD1EED41BF1BA2B002B56B0 /* Parser.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F041DAD1BF1B76800C51207 /* Parser.m */; };
 		2FEF76A21C2B88750017311E /* Prefs.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FEF76A11C2B88750017311E /* Prefs.m */; };
 		2FEF76A31C2B88750017311E /* Prefs.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FEF76A11C2B88750017311E /* Prefs.m */; };
+		BF5B43151CA1508F002E7D41 /* SwiftParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5B43141CA1508F002E7D41 /* SwiftParserTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		2FD1EECF1BF1B9B1002B56B0 /* StringTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StringTest.m; sourceTree = "<group>"; };
 		2FEF76A01C2B88750017311E /* Prefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Prefs.h; sourceTree = "<group>"; };
 		2FEF76A11C2B88750017311E /* Prefs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Prefs.m; sourceTree = "<group>"; };
+		BF5B43141CA1508F002E7D41 /* SwiftParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwiftParserTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,19 +131,19 @@
 		2F041D931BF1B5C100C51207 /* Swimat */ = {
 			isa = PBXGroup;
 			children = (
-				2F041D971BF1B5C100C51207 /* Swimat.h */,
-				2F041D981BF1B5C100C51207 /* Swimat.m */,
+				2F2F5C731C0B37CB0090D0C5 /* Categories */,
+				2F041D9D1BF1B5C100C51207 /* Info.plist */,
 				2F041D9A1BF1B5C100C51207 /* NSObject_Extension.h */,
 				2F041D9B1BF1B5C100C51207 /* NSObject_Extension.m */,
-				2F041D9D1BF1B5C100C51207 /* Info.plist */,
-				2F041D941BF1B5C100C51207 /* Supporting Files */,
-				2F2F5C731C0B37CB0090D0C5 /* category */,
-				2F041DA31BF1B6D700C51207 /* SwiftParser.h */,
-				2F041DA41BF1B6D700C51207 /* SwiftParser.m */,
 				2F041DAC1BF1B76800C51207 /* Parser.h */,
 				2F041DAD1BF1B76800C51207 /* Parser.m */,
 				2FEF76A01C2B88750017311E /* Prefs.h */,
 				2FEF76A11C2B88750017311E /* Prefs.m */,
+				2F041D941BF1B5C100C51207 /* Supporting Files */,
+				2F041DA31BF1B6D700C51207 /* SwiftParser.h */,
+				2F041DA41BF1B6D700C51207 /* SwiftParser.m */,
+				2F041D971BF1B5C100C51207 /* Swimat.h */,
+				2F041D981BF1B5C100C51207 /* Swimat.m */,
 			);
 			path = Swimat;
 			sourceTree = "<group>";
@@ -157,16 +159,17 @@
 		2F041DB41BF1B94F00C51207 /* SwimatTest */ = {
 			isa = PBXGroup;
 			children = (
-				2F041DB51BF1B94F00C51207 /* SwimatTest.m */,
 				2F041DB71BF1B94F00C51207 /* Info.plist */,
 				2FD1EECB1BF1B992002B56B0 /* MutableStringTest.m */,
 				2FD1EECD1BF1B9A2002B56B0 /* ParserTest.m */,
 				2FD1EECF1BF1B9B1002B56B0 /* StringTest.m */,
+				BF5B43141CA1508F002E7D41 /* SwiftParserTest.m */,
+				2F041DB51BF1B94F00C51207 /* SwimatTest.m */,
 			);
 			path = SwimatTest;
 			sourceTree = "<group>";
 		};
-		2F2F5C731C0B37CB0090D0C5 /* category */ = {
+		2F2F5C731C0B37CB0090D0C5 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
 				2F2F5C741C0B37F20090D0C5 /* NSMutableString+Common.h */,
@@ -176,7 +179,7 @@
 				2FAF21A01C30E6BB00A1E40A /* NSDocument+Common.h */,
 				2FAF21A11C30E6BB00A1E40A /* NSDocument+Common.m */,
 			);
-			name = category;
+			name = Categories;
 			sourceTree = "<group>";
 		};
 		2FCE0E501C05D2220000DF1B /* DTXcodeUtils */ = {
@@ -308,6 +311,7 @@
 				2F041DB61BF1B94F00C51207 /* SwimatTest.m in Sources */,
 				2FD1EECE1BF1B9A2002B56B0 /* ParserTest.m in Sources */,
 				2FD1EED11BF1BA1F002B56B0 /* SwiftParser.m in Sources */,
+				BF5B43151CA1508F002E7D41 /* SwiftParserTest.m in Sources */,
 				2FD1EED01BF1B9B1002B56B0 /* StringTest.m in Sources */,
 				2F2F5C7A1C0B39140090D0C5 /* NSMutableString+Common.m in Sources */,
 				2F39CCA51C1A7A5A00005EC5 /* DTXcodeUtils.m in Sources */,

--- a/Swimat/Prefs.h
+++ b/Swimat/Prefs.h
@@ -7,6 +7,24 @@ extern NSString * const INDENT_TAB;
 extern NSString * const INDENT_SPACE2;
 extern NSString * const INDENT_SPACE4;
 
+/**
+ *  Different values for the "break before opening brace" rule. For clarity: this rule only affects '{' ("brace").
+ */
+typedef NS_ENUM(NSInteger, SWMBreakBeforeOpeningBraceRule) {
+    /**
+     *  Default rule.
+     */
+    SWMBreakBeforeOpeningBraceRuleIgnore = 0,
+    /**
+     *  Removes all newlines before opening braces.
+     */
+    SWMBreakBeforeOpeningBraceRuleRemove,
+    /**
+     *  Removes and inserts newlines before opening braces so that in the formatted output there is one newline before each opening brace.
+     */
+    SWMBreakBeforeOpeningBraceRuleForce,
+};
+
 +(void) setIndent:(NSString *)value;
 
 +(NSString *) getIndent;
@@ -26,5 +44,11 @@ extern NSString * const INDENT_SPACE4;
 +(void) setIndentEmptyLine:(bool) format;
 
 +(bool) isIndentEmptyLine;
+
++ (void)setBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule;
++ (SWMBreakBeforeOpeningBraceRule)breakBeforeOpeningBraceRule;
+
++ (NSString *)enabledBreakBeforeOpeningBraceRuleMenuItemTitle;
++ (NSString *)menuItemTitleForBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule;
 
 @end

--- a/Swimat/Prefs.m
+++ b/Swimat/Prefs.m
@@ -9,6 +9,10 @@ NSString * const TAG_INDENT = @"indent";
 NSString * const INDENT_TAB = @"Tab Indent";
 NSString * const INDENT_SPACE2 = @"2 Space Indent";
 NSString * const INDENT_SPACE4 = @"4 Space Indent";
+static NSString *const BREAK_BEFORE_OPENING_BRACE = @"BreakBeforeOpeningBraceRule";
+static NSString *const BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_IGNORE = @"Ignore";
+static NSString *const BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_REMOVE = @"Remove";
+static NSString *const BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_FORCE = @"Force";
 
 +(void) setIndent:(NSString *)value {
 	NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
@@ -74,5 +78,45 @@ NSString * const INDENT_SPACE4 = @"4 Space Indent";
 	return [prefs boolForKey:TAG_INDENT_EMPTY_LINE];
 }
 
+#pragma mark - Formatting rule: Break before opening brace
+
++ (void)setBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setInteger:rule forKey:BREAK_BEFORE_OPENING_BRACE];
+    [defaults synchronize];
+}
+
++ (SWMBreakBeforeOpeningBraceRule)breakBeforeOpeningBraceRule {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    id setting = [defaults objectForKey:BREAK_BEFORE_OPENING_BRACE];
+    if (setting == nil) {
+        // Initialize setting with default rule
+        [defaults setInteger:SWMBreakBeforeOpeningBraceRuleIgnore forKey:BREAK_BEFORE_OPENING_BRACE];
+        [defaults synchronize];
+    }
+    
+    return [defaults integerForKey:BREAK_BEFORE_OPENING_BRACE];
+}
+
++ (NSString *)menuItemTitleForBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule {
+    switch (rule) {
+        case SWMBreakBeforeOpeningBraceRuleIgnore: {
+            return NSLocalizedString(BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_IGNORE, nil);
+        }
+            
+        case SWMBreakBeforeOpeningBraceRuleRemove: {
+            return NSLocalizedString(BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_REMOVE, nil);
+        }
+            
+        case SWMBreakBeforeOpeningBraceRuleForce: {
+            return NSLocalizedString(BREAK_BEFORE_OPENING_BRACE_ITEM_TITLE_FORCE, nil);
+        }
+    }
+}
+
++ (NSString *)enabledBreakBeforeOpeningBraceRuleMenuItemTitle {
+    SWMBreakBeforeOpeningBraceRule enabledRule = [self breakBeforeOpeningBraceRule];
+    return [self menuItemTitleForBreakBeforeOpeningBraceRule:enabledRule];
+}
 
 @end

--- a/Swimat/SwiftParser.m
+++ b/Swimat/SwiftParser.m
@@ -9,6 +9,7 @@
 bool inSwitch; // TODO: change to stack if need nested
 int switchBlockCount; // change to stack if need nested
 bool indentEmptyLine;
+SWMBreakBeforeOpeningBraceRule breakBeforeOpeningBraceRule;
 NSMutableArray *blockStack;
 NSString *curBlock;
 NSMutableArray *indentStack;
@@ -32,6 +33,7 @@ int curIndent = 0;
 	switchBlockCount = 0;
 	indentString = [Prefs getIndentString];
 	indentEmptyLine = [Prefs isIndentEmptyLine];
+    breakBeforeOpeningBraceRule = [Prefs breakBeforeOpeningBraceRule];
 	
 	newRange = NSMakeRange(range.location, range.length);// TODO need?
 	
@@ -252,19 +254,59 @@ int curIndent = 0;
 		if (![orString isCompleteLine:strIndex curBlock:curBlock]) {
 			onetimeIndent++;
 		}
-		BOOL shouldAddEmtyLine = !([self isEmptyLine] && ([self isNextLineEmpty:strIndex + 1] || [self isNextLineLowerBrackets:strIndex + 1]));
-		if (indentEmptyLine) {
-			[self trimWithIndent];
-		} else {
-			[retString trim];
-		}
-		if (shouldAddEmtyLine) {
+        
+        if (indentEmptyLine) {
+            [self trimWithIndent];
+        } else {
+            [retString trim];
+        }
+        
+        BOOL shouldAddEmptyLine = YES;
+        BOOL shouldIndent = YES;
+        
+        const NSUInteger lastCharIndex = [orString lastCharIndex:(strIndex + 1) defaults:NSNotFound];
+        const unichar lastChar = (lastCharIndex == NSNotFound ? ' ' : [orString characterAtIndex:lastCharIndex]);
+        
+        const NSUInteger nextCharIndex = [orString nextCharIndex:(strIndex + 1) defaults:NSNotFound];
+        const unichar nextChar = (nextCharIndex == NSNotFound ? ' ' : [orString characterAtIndex:nextCharIndex]);
+        
+        const NSUInteger nextCharOrNewlineIndex = [orString nextNonSpaceIndex:(strIndex + 1) defaults:NSNotFound];
+        const unichar nextCharOrNewline = (nextCharOrNewlineIndex == NSNotFound ? ' ' : [orString characterAtIndex:nextCharOrNewlineIndex]);
+        
+        if ((breakBeforeOpeningBraceRule == SWMBreakBeforeOpeningBraceRuleRemove) && (nextChar == '{')) {
+            // There may not be a newline before an opening brace
+            shouldAddEmptyLine = NO;
+            shouldIndent = NO;
+        } else {
+            if ([self isEmptyLine]) {
+                if (nextCharOrNewline == '\n') {
+                    // There may not be more than one consecutive empty line
+                    shouldAddEmptyLine = NO;
+                } else if ([Parser isLowerBrackets:nextCharOrNewline]) {
+                    // There may not be an empty line before a closing bracket
+                    shouldAddEmptyLine = NO;
+                } else if ([Parser isUpperBrackets:lastChar]) {
+                    // There may not be an empty line after an opening bracket
+                    shouldAddEmptyLine = NO;
+                    shouldIndent = NO;
+                }
+            } // else: this line is not empty and a newline is always OK
+        }
+		
+		if (shouldAddEmptyLine) {
 			[self appendString:@"\n"];
 		} else {
 			strIndex++;
 		}
+        
+        NSUInteger nextIndex;
+        if (shouldIndent) {
+            nextIndex = [self addIndent:retString];
+        } else {
+            nextIndex = strIndex;
+        }
 		
-		return [self addIndent:retString];
+        return nextIndex;
 	}
 	
 	return 0;
@@ -597,6 +639,20 @@ int curIndent = 0;
 		}
 		
 		unichar lastChar = [orString lastChar:strIndex - 1 defaults:'\n'];
+        
+        if ((c == '{') && (breakBeforeOpeningBraceRule == SWMBreakBeforeOpeningBraceRuleForce)) {
+            NSUInteger lastNonSpaceIndex = [orString lastNonSpaceIndex:(strIndex - 1) defaults:NSNotFound];
+            if (lastNonSpaceIndex != NSNotFound) {
+                unichar lastNonSpace = [orString characterAtIndex:lastNonSpaceIndex];
+                if (lastNonSpace != '\n') {
+                    // Insert a newline before the brace
+                    [retString appendString:@"\n"];
+                    [self trimWithIndent];
+                    
+                    lastChar = '\n';
+                }
+            }
+        }
 		
 		if ([Parser isLowerBrackets:lastChar]) {
 			if (c == '{') {
@@ -614,21 +670,25 @@ int curIndent = 0;
 					} else if ([Parser isAZ:lastChar] || lastChar == ']'){
 						[self trimWithIndent];
 					}
-				}
-					break;
-				case '{':
-					if (![Parser isUpperBrackets:lastChar]) {
-						[retString keepSpace];
+				} break;
+                    
+                case '{': {
+                    if (![Parser isUpperBrackets:lastChar]) {
+                        [retString keepSpace];
 					}
-					break;
+                } break;
+                    
 				default:
 					break;
 			}
 		}
+        
 		[self appendChar:c];
+        
 		if (c == '{') {
 			[self appendString:@" "];
 		}
+        
 		indent = curIndent + 1;
 		return [orString nextNonSpaceIndex:strIndex defaults:strIndex];
 	} else if ([Parser isLowerBrackets:c]) {

--- a/Swimat/SwiftParser.m
+++ b/Swimat/SwiftParser.m
@@ -289,6 +289,10 @@ int curIndent = 0;
                     // There may not be an empty line after an opening bracket
                     shouldAddEmptyLine = NO;
                     shouldIndent = NO;
+                } else if ([Parser isUpperBrackets:nextChar]) {
+                    // There may not be an empty line before an opening bracket
+                    shouldAddEmptyLine = NO;
+                    shouldIndent = NO;
                 }
             } // else: this line is not empty and a newline is always OK
         }

--- a/Swimat/category/NSString+Common.h
+++ b/Swimat/category/NSString+Common.h
@@ -32,6 +32,8 @@
  */
 -(NSUInteger) nextIndex:(NSUInteger) index defaults:(NSUInteger) value compare: (bool(^)(NSString *, NSUInteger)) checker;
 
+-(NSUInteger) nextCharIndex:(NSUInteger) index defaults:(NSUInteger) value;
+
 /**
  @brief find next space index
  */
@@ -56,6 +58,11 @@
  @brief find last index of string
  */
 -(NSUInteger) lastIndex:(NSUInteger) index defaults:(NSUInteger) value compare: (bool(^)(NSString *, NSUInteger)) checker;
+
+/**
+ @brief find last character
+ */
+-(NSUInteger) lastCharIndex:(NSUInteger) index defaults:(NSUInteger) value;
 
 /**
  @brief find last space

--- a/SwimatTest/SwiftParserTest.m
+++ b/SwimatTest/SwiftParserTest.m
@@ -50,7 +50,7 @@
 
 static NSString *const SWMSwiftParserTestNoNewlineSourceString = @"func a(b:Int){\nreturn (b+1)\n}";
 static NSString *const SWMSwiftParserTestSingleNewlineSourceString = @"func a(b:Int)\n{\nreturn (b+1)\n}";
-static NSString *const SWMSwiftParserTestMultipleNewlineSourceString = @"func a(b:Int)\n\n{\nreturn (b+1)\n}";
+static NSString *const SWMSwiftParserTestMultipleNewlineSourceString = @"func a(b:Int)\n\n\n{\nreturn (b+1)\n}";
 
 - (void)enableBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule {
     [Prefs setBreakBeforeOpeningBraceRule:rule];

--- a/SwimatTest/SwiftParserTest.m
+++ b/SwimatTest/SwiftParserTest.m
@@ -1,0 +1,186 @@
+//
+//  SwiftParserTest.m
+//  Swimat
+//
+//  Created by Reimar Twelker on 18.03.16.
+//  Copyright © 2016 jintin. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SwiftParser.h"
+#import "Prefs.h"
+
+@interface SwiftParserTest : XCTestCase
+
+@property (nonatomic, strong) SwiftParser *parser;
+
+@end
+
+@implementation SwiftParserTest
+
+- (void)setUp {
+    [super setUp];
+    self.parser = [[SwiftParser alloc] init];
+}
+
+- (void)tearDown {
+    self.parser = nil;
+    [super tearDown];
+}
+
+- (void)logSourceCodeString:(NSString *)string label:(NSString *)label {
+    NSString *labelWithDelimiter = (label != nil ? [NSString stringWithFormat:@"\n\n%@:\n", label] : @"\n");
+    NSLog(@"%@%@\n\n", labelWithDelimiter, string);
+}
+
+- (void)logInput:(NSString *)string {
+    [self logSourceCodeString:string label:@"Input"];
+}
+
+- (void)logOutput:(NSString *)string {
+    [self logSourceCodeString:string label:@"Output"];
+}
+
+- (void)logInput:(NSString *)inputString output:(NSString *)outputString {
+    [self logInput:inputString];
+    [self logOutput:outputString];
+}
+
+#pragma mark - Formatting rule: Break before opening brace
+
+static NSString *const SWMSwiftParserTestNoNewlineSourceString = @"func a(b:Int){\nreturn (b+1)\n}";
+static NSString *const SWMSwiftParserTestSingleNewlineSourceString = @"func a(b:Int)\n{\nreturn (b+1)\n}";
+static NSString *const SWMSwiftParserTestMultipleNewlineSourceString = @"func a(b:Int)\n\n{\nreturn (b+1)\n}";
+
+- (void)enableBreakBeforeOpeningBraceRule:(SWMBreakBeforeOpeningBraceRule)rule {
+    [Prefs setBreakBeforeOpeningBraceRule:rule];
+}
+
+#pragma mark Ignore
+
+- (void)test_breakBeforeOpeningBraceRuleIgnore_shouldKeepNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleIgnore];
+    
+    NSString *input = SWMSwiftParserTestSingleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 1);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleIgnore_shouldKeepOneNewline_ifThereAreMultipleNewlines {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleIgnore];
+    
+    NSString *input = SWMSwiftParserTestMultipleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+ 
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 1);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleIgnore_shouldDoNothing_ifThereIsNoNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleIgnore];
+    
+    NSString *input = SWMSwiftParserTestNoNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 0);
+}
+
+#pragma mark Remove
+
+- (void)test_breakBeforeOpeningBraceRuleRemove_shouldRemoveNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleRemove];
+    
+    NSString *input = SWMSwiftParserTestSingleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 0);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleRemove_shouldRemoveAllNewlines {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleRemove];
+    
+    NSString *input = SWMSwiftParserTestMultipleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 0);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleRemove_shouldDoNothing_ifThereIsNoNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleRemove];
+    
+    NSString *input = SWMSwiftParserTestNoNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 0);
+}
+
+#pragma mark Force
+
+- (void)test_breakBeforeOpeningBraceRuleForce_shouldDoNothing_ifThereIsOneNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleForce];
+    
+    NSString *input = SWMSwiftParserTestSingleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 1);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleForce_shouldInsertOneNewline_ifThereIsNoNewline {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleForce];
+    
+    NSString *input = SWMSwiftParserTestNoNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 1);
+}
+
+- (void)test_breakBeforeOpeningBraceRuleForce_shouldKeepOneNewline_ifThereAreMultipleNewlines {
+    [self enableBreakBeforeOpeningBraceRule:SWMBreakBeforeOpeningBraceRuleForce];
+    
+    NSString *input = SWMSwiftParserTestMultipleNewlineSourceString;
+    NSString *output = [self.parser formatString:input withRange:NSMakeRange(0, input.length)];
+    [self logInput:input output:output];
+    
+    NSInteger outputCount = [self numberOfNewlinesInString:output betweenFirstOccurrenceOfSubstring:@")" andFirstOccurrenceOfSubstring:@"{"];
+    XCTAssertEqual(outputCount, 1);
+}
+
+#pragma mark - Helpers
+
+- (NSInteger)numberOfNewlinesInString:(NSString *)string betweenFirstOccurrenceOfSubstring:(NSString *)substring1 andFirstOccurrenceOfSubstring:(NSString *)substring2 {
+    NSInteger n = 0;
+    NSString *substring = [self substringOfString:string betweenFirstOccurrenceOfSubstring:substring1 andFirstOccurrenceOfSubstring:substring2];
+    for (int i = 0; i < substring.length; ++i) {
+        if ([substring characterAtIndex:i] == '\n') {
+            ++n;
+        }
+    }
+    
+    return n;
+}
+
+- (NSString *)substringOfString:(NSString *)string betweenFirstOccurrenceOfSubstring:(NSString *)substring1 andFirstOccurrenceOfSubstring:(NSString *)substring2 {
+    NSRange r1 = [string rangeOfString:substring1];
+    NSRange r2 = [string rangeOfString:substring2 options:0 range:NSMakeRange(r1.location, string.length - r1.location)];
+    NSRange substringRange = NSMakeRange(r1.location + r1.length, r2.location - (r1.location + r1.length));
+    XCTAssert(substringRange.location >= 0 && substringRange.length >= 0);
+    return [string substringWithRange:substringRange];
+}
+
+@end


### PR DESCRIPTION
I've implemented a rule which formats newlines before opening braces, e.g. before method bodies.

Possible values:
- Ignore: does nothing, default setting
- Remove: removes all newlines before opening braces
- Force: inserts one newline before each opening brace

The Xcode plugin displays a new submenu containing the various rules.

Added tests for the new rule.
