### PR TITLE
Remove extraneous build steps from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: objective-c
 osx_image: xcode8.2
 
 script:
-  - xcodebuild -scheme Swimat CODE_SIGNING_ALLOWED=NO
   - xcodebuild -scheme Swimat test CODE_SIGNING_ALLOWED=NO
-  - xcodebuild -scheme CLI CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
So, it appears that the test target builds the Swimat scheme, which contains the CLI scheme! So we only need to have one build step for 100% code coverage.