### PR TITLE
Improve preferences management (#2)

### DIFF
--- a/Extension/SourceEditorCommand.swift
+++ b/Extension/SourceEditorCommand.swift
@@ -17,10 +17,8 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
         } else {
             Indent.char = String(repeating: " ", count: invocation.buffer.indentationWidth)
         }
-        Indent.paraAlign = Pref.isParaAlign()
 
         let parser = SwiftParser(string: invocation.buffer.completeBuffer)
-        parser.autoRemoveChar = Pref.isAutoRemoveChar()
         do {
             let newLines = try parser.format().components(separatedBy: "\n")
             let lines = invocation.buffer.lines

--- a/Extension/Supporting Files/Extension.entitlements
+++ b/Extension/Supporting Files/Extension.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>com.jintin.swimat.config</string>
+		<string>com.jintin.swimat.configuration</string>
 	</array>
 </dict>
 </plist>

--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+class Preferences {
+    static let parameterAlignment = "areParametersAligned"
+    static let removeSemicolons = "areSemicolonsRemoved"
+
+    private static let sharedUserDefaults = {
+        UserDefaults(suiteName: "com.jintin.swimat.configuration")!
+    }()
+
+    static var areParametersAligned: Bool {
+        get {
+            return Preferences.sharedUserDefaults.bool(forKey: Preferences.parameterAlignment)
+        }
+        set {
+            Preferences.sharedUserDefaults.set(newValue, forKey: Preferences.parameterAlignment)
+            Preferences.sharedUserDefaults.synchronize()
+        }
+    }
+    var areParametersAligned = false
+
+    static var areSemicolonsRemoved: Bool {
+        get {
+            return Preferences.sharedUserDefaults.bool(forKey: Preferences.removeSemicolons)
+        }
+        set {
+            Preferences.sharedUserDefaults.set(newValue, forKey: Preferences.removeSemicolons)
+            Preferences.sharedUserDefaults.synchronize()
+        }
+    }
+    var areSemicolonsRemoved = false
+}

--- a/Parser/SwiftParser.swift
+++ b/Parser/SwiftParser.swift
@@ -44,10 +44,21 @@ class SwiftParser {
     var isNextSwitch: Bool = false
     var autoRemoveChar: Bool = false
 
-    init(string: String) {
+    init(string: String, preferences: Preferences? = nil) {
         self.string = string
         self.strIndex = string.startIndex
         self.newlineIndex = string.startIndex
+
+        if let preferences = preferences {
+            // Use the preferences given (for example, when testing)
+            Indent.paraAlign = preferences.areParametersAligned
+            autoRemoveChar = preferences.areSemicolonsRemoved
+        } else {
+            // Fallback on user-defined preferences
+            Indent.paraAlign = Preferences.areParametersAligned
+            autoRemoveChar = Preferences.areSemicolonsRemoved
+            return
+        }
     }
 
     func format() throws -> String {

--- a/Swimat.xcodeproj/project.pbxproj
+++ b/Swimat.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		2F2BDB331DA90DA0009A137B /* ExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2BDB321DA90DA0009A137B /* ExtensionTest.swift */; };
-		2F3595481E44D9AE001E1435 /* Pref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Pref.swift */; };
-		2F3595491E44D9AE001E1435 /* Pref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Pref.swift */; };
-		2F35954A1E44D9AE001E1435 /* Pref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Pref.swift */; };
-		2F35954B1E44D9AE001E1435 /* Pref.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Pref.swift */; };
+		2F3595481E44D9AE001E1435 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Preferences.swift */; };
+		2F3595491E44D9AE001E1435 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Preferences.swift */; };
+		2F35954A1E44D9AE001E1435 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Preferences.swift */; };
+		2F35954B1E44D9AE001E1435 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3595471E44D9AE001E1435 /* Preferences.swift */; };
 		2F4C327C1E573EB70089CD82 /* FormatTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4C327B1E573EB70089CD82 /* FormatTest.swift */; };
 		2F5745DD1D8A83C500094D06 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F5745DC1D8A83C500094D06 /* AppDelegate.swift */; };
 		2F5745DF1D8A83C500094D06 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F5745DE1D8A83C500094D06 /* Assets.xcassets */; };
@@ -93,7 +93,7 @@
 
 /* Begin PBXFileReference section */
 		2F2BDB321DA90DA0009A137B /* ExtensionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionTest.swift; sourceTree = "<group>"; };
-		2F3595471E44D9AE001E1435 /* Pref.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pref.swift; sourceTree = "<group>"; };
+		2F3595471E44D9AE001E1435 /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		2F4C327B1E573EB70089CD82 /* FormatTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatTest.swift; sourceTree = "<group>"; };
 		2F5745D91D8A83C500094D06 /* Swimat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Swimat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F5745DC1D8A83C500094D06 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -246,7 +246,7 @@
 				2F6D8BF51E0435B5006CFC50 /* Extension.swift */,
 				2F6D8BF61E0435B5006CFC50 /* Indent.swift */,
 				2F6D8BF71E0435B5006CFC50 /* Parser.swift */,
-				2F3595471E44D9AE001E1435 /* Pref.swift */,
+				2F3595471E44D9AE001E1435 /* Preferences.swift */,
 				2F6D8BF81E0435B5006CFC50 /* SwiftParser.swift */,
 			);
 			path = Parser;
@@ -432,7 +432,8 @@
 				2F6D8BFD1E0435B5006CFC50 /* Indent.swift in Sources */,
 				2F5745DD1D8A83C500094D06 /* AppDelegate.swift in Sources */,
 				2F6D8BF91E0435B5006CFC50 /* Extension.swift in Sources */,
-				2F3595481E44D9AE001E1435 /* Pref.swift in Sources */,
+				2F3595481E44D9AE001E1435 /* Preferences.swift in Sources */,
+				49329DF31E6A0406005C266E /* PreviewViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -441,8 +442,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F4C327C1E573EB70089CD82 /* FormatTest.swift in Sources */,
-				2F3595491E44D9AE001E1435 /* Pref.swift in Sources */,
+				2F3595491E44D9AE001E1435 /* Preferences.swift in Sources */,
 				2F6D8C061E0435B5006CFC50 /* SwiftParser.swift in Sources */,
+				49F37BEF1F0DB06800E092B1 /* TestSetup.swift in Sources */,
 				2F6D8C021E0435B5006CFC50 /* Parser.swift in Sources */,
 				2F6D8BFE1E0435B5006CFC50 /* Indent.swift in Sources */,
 				2F2BDB331DA90DA0009A137B /* ExtensionTest.swift in Sources */,
@@ -460,7 +462,7 @@
 				2F6D8C031E0435B5006CFC50 /* Parser.swift in Sources */,
 				2F5746031D8A83E600094D06 /* SourceEditorExtension.swift in Sources */,
 				2F5746051D8A83E600094D06 /* SourceEditorCommand.swift in Sources */,
-				2F35954A1E44D9AE001E1435 /* Pref.swift in Sources */,
+				2F35954A1E44D9AE001E1435 /* Preferences.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -470,7 +472,7 @@
 			files = (
 				2F6D8C0E1E0435CA006CFC50 /* OptionParser.swift in Sources */,
 				2F6D8C0D1E0435CA006CFC50 /* main.swift in Sources */,
-				2F35954B1E44D9AE001E1435 /* Pref.swift in Sources */,
+				2F35954B1E44D9AE001E1435 /* Preferences.swift in Sources */,
 				2F6D8C041E0435B5006CFC50 /* Parser.swift in Sources */,
 				2F6D8C081E0435B5006CFC50 /* SwiftParser.swift in Sources */,
 				2F6D8C0C1E0435CA006CFC50 /* ErrorHandling.swift in Sources */,

--- a/Swimat/Supporting Files/Swimat.entitlements
+++ b/Swimat/Supporting Files/Swimat.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>com.jintin.swimat.config</string>
+		<string>com.jintin.swimat.configuration</string>
 	</array>
 </dict>
 </plist>

--- a/Swimat/SwimatViewController.swift
+++ b/Swimat/SwimatViewController.swift
@@ -30,8 +30,8 @@ class SwimatViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do view setup here.
-        paraAlign.state = Pref.isParaAlign() ? 1 : 0
-        autoRemoveChar.state = Pref.isParaAlign() ? 1 : 0
+        paraAlign.state = Preferences.areParametersAligned ? 1 : 0
+        autoRemoveChar.state = Preferences.areSemicolonsRemoved ? 1 : 0
         formatSource()
     }
 
@@ -44,17 +44,17 @@ class SwimatViewController: NSViewController {
     }
 
     @IBAction func paraAlignClick(_ sender: NSButton) {
-        Pref.setParaAlign(isAlign: sender.state == 1)
+        Preferences.areParametersAligned = sender.state == NSOnState
         formatSource()
     }
 
     @IBAction func autoRemoveChar(_ sender: NSButton) {
-        Pref.setParaAlign(isAlign: sender.state == 1)
+        Preferences.areSemicolonsRemoved = sender.state == NSOnState
     }
     func formatSource() {
         Indent.char = "    "
         Indent.size = 4
-        Indent.paraAlign = Pref.isParaAlign()
+        Indent.paraAlign = Preferences.areParametersAligned
         let parser = SwiftParser(string: source.stringValue)
         do {
             let newValue = try parser.format()

--- a/SwimatTests/FormatTest.swift
+++ b/SwimatTests/FormatTest.swift
@@ -4,15 +4,17 @@ class FormatTest: XCTestCase {
 
     func formatAlign(res: String, expect: String) {
         Indent.char = "    "
-        Indent.paraAlign = true
-        let parser = SwiftParser(string: res)
+        let preferences = Preferences()
+        preferences.areParametersAligned = true
+        let parser = SwiftParser(string: res, preferences: preferences)
         format(parser: parser, expect: expect)
     }
 
     func formatNonAlign(res: String, expect: String) {
         Indent.char = "    "
-        Indent.paraAlign = false
-        let parser = SwiftParser(string: res)
+        let preferences = Preferences()
+        preferences.areParametersAligned = false
+        let parser = SwiftParser(string: res, preferences: preferences)
         format(parser: parser, expect: expect)
     }
 


### PR DESCRIPTION
Share preferences across all targets, improve API consistency, and allow for
"testing" configurations that are separate from the user's preferences