### PR TITLE
Fix warnings in Xcode 9.1

### DIFF
--- a/Parser/Extension.swift
+++ b/Parser/Extension.swift
@@ -3,7 +3,7 @@ import Foundation
 extension String {
 
     var last: Character {
-        return characters.last ?? "\0" as Character
+        return last ?? "\0" as Character
     }
 
     func lastWord() -> String {

--- a/Parser/Indent.swift
+++ b/Parser/Indent.swift
@@ -21,7 +21,7 @@ enum IndentType: Character {
 class Indent {
     static var char: String = "" {
         didSet {
-            size = char.characters.count
+            size = char.count
         }
     }
     static var size: Int = 0

--- a/Parser/Parser.swift
+++ b/Parser/Parser.swift
@@ -18,7 +18,7 @@ extension SwiftParser {
 
     func isPrevious(str: String) -> Bool {
 
-        if let start = string.index(strIndex, offsetBy: -str.characters.count, limitedBy: string.startIndex) {
+        if let start = string.index(strIndex, offsetBy: -str.count, limitedBy: string.startIndex) {
             if let _ = string.range(of: str, options: [], range: start ..< strIndex) {
                 return true
             }

--- a/Parser/SwiftParser.swift
+++ b/Parser/SwiftParser.swift
@@ -158,7 +158,7 @@ class SwiftParser {
             return checkLine(char)
         case " ", "\t":
             if retString.lastWord() == "if" {
-                let leading = retString.characters.count - newlineIndex
+                let leading = retString.count - newlineIndex
                 let newIndent = Indent(with: indent, offset: leading, type: IndentType(rawValue: "f"))
                 indentStack.append(indent)
                 indent = newIndent
@@ -178,7 +178,7 @@ class SwiftParser {
                     }
                 }
             }
-            let offset = retString.characters.count - newlineIndex
+            let offset = retString.count - newlineIndex
             let newIndent = Indent(with: indent, offset: offset, type: IndentType(rawValue: char))
             indentStack.append(indent)
             indent = newIndent
@@ -290,7 +290,7 @@ class SwiftParser {
 
     func checkLine(_ char: Character, checkLast: Bool = true) -> String.Index {
         trim()
-        newlineIndex = retString.characters.count - 1
+        newlineIndex = retString.count - 1
         if checkLast {
             checkLineEnd()
         } else {


### PR DESCRIPTION
`String` is a `Collection` now so `characters` is not necessary anymore.