### PR TITLE
Fix: Remove semicolons preference not saved

### DIFF
--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -33,7 +33,7 @@ class Preferences: Codable {
     }
 
     static func setBool(key: String, value: Bool) {
-        sharedUserDefaults.set(value, forKey: Preferences.parameterAlignment)
+        sharedUserDefaults.set(value, forKey: key)
         sharedUserDefaults.synchronize()
     }
 


### PR DESCRIPTION
A harcoded parameter prevented the preference from taking effect.
