### PR TITLE
read configuration from file

### DIFF
--- a/CLI/OptionParser.swift
+++ b/CLI/OptionParser.swift
@@ -11,7 +11,6 @@ struct Option {
 class Options {
     static var shared = Options()
 
-    var preference: Preferences?
     var configurationFile = ".swimat.json"
     var recursive = false
     var verbose = false
@@ -126,10 +125,10 @@ class Options {
 
         do {
             let data = try Data(contentsOf: URL(fileURLWithPath: configurationFile))
-            preference = try JSONDecoder().decode(Preferences.self, from: data)
+            Preferences.shared = try JSONDecoder().decode(Preferences.self, from: data)
             if verbose {
                 print("Used config file \(configurationFile)")
-                preference?.printDescription()
+                Preferences.shared?.printDescription()
             }
         } catch DecodingError.dataCorrupted {
             fatalError("Can't read \(configurationFile) file. Data corrupted.")

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -58,7 +58,7 @@ for path in paths {
             (file.pathExtension) as CFString,
             nil)?.takeRetainedValue(),
             uti == "public.swift-source" as CFString {
-            let parser = SwiftParser(string: try String(contentsOf: file))
+            let parser = SwiftParser(string: try String(contentsOf: file), preferences: options.preference)
             let formattedText = try parser.format()
             try formattedText.write(to: file, atomically: true, encoding: .utf8)
             files += 1

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -58,7 +58,7 @@ for path in paths {
             (file.pathExtension) as CFString,
             nil)?.takeRetainedValue(),
             uti == "public.swift-source" as CFString {
-            let parser = SwiftParser(string: try String(contentsOf: file), preferences: options.preference)
+            let parser = SwiftParser(string: try String(contentsOf: file))
             let formattedText = try parser.format()
             try formattedText.write(to: file, atomically: true, encoding: .utf8)
             files += 1

--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 class Preferences: Codable {
-    static let parameterAlignment = "areParametersAligned"
-    static let removeSemicolons = "areSemicolonsRemoved"
+    enum Key: String, CodingKey {
+        case parameterAlignment = "areParametersAligned"
+        case removeSemicolons = "areSemicolonsRemoved"
+    }
 
     private static let sharedUserDefaults = {
         UserDefaults(suiteName: "com.jintin.swimat.configuration")!
@@ -10,31 +12,47 @@ class Preferences: Codable {
 
     static var areParametersAligned: Bool {
         get {
-            return getBool(key: parameterAlignment)
+            return getBool(key: Key.parameterAlignment)
         }
         set {
-            setBool(key: parameterAlignment, value: newValue)
+            setBool(key: Key.parameterAlignment, value: newValue)
         }
     }
-    var areParametersAligned = false
+    var areParametersAligned: Bool
 
     static var areSemicolonsRemoved: Bool {
         get {
-            return getBool(key: removeSemicolons)
+            return getBool(key: Key.removeSemicolons)
         }
         set {
-            setBool(key: removeSemicolons, value: newValue)
+            setBool(key: Key.removeSemicolons, value: newValue)
         }
     }
-    var areSemicolonsRemoved = false
+    var areSemicolonsRemoved: Bool
 
-    static func getBool(key: String) -> Bool {
-        return sharedUserDefaults.bool(forKey: key)
+    init() {
+        areParametersAligned = false
+        areSemicolonsRemoved = false
     }
 
-    static func setBool(key: String, value: Bool) {
-        sharedUserDefaults.set(value, forKey: key)
+    required convenience init(from decoder: Decoder) throws {
+        self.init()
+        let values = try decoder.container(keyedBy: Key.self)
+        areParametersAligned = (try? values.decode(Bool.self, forKey: .parameterAlignment)) ?? false
+        areSemicolonsRemoved = (try? values.decode(Bool.self, forKey: .removeSemicolons)) ?? false
+    }
+
+    static func getBool(key: Key) -> Bool {
+        return sharedUserDefaults.bool(forKey: key.rawValue)
+    }
+
+    static func setBool(key: Key, value: Bool) {
+        sharedUserDefaults.set(value, forKey: key.rawValue)
         sharedUserDefaults.synchronize()
     }
 
+    func printDescription() {
+        print(Key.parameterAlignment.rawValue, areParametersAligned)
+        print(Key.removeSemicolons.rawValue, areSemicolonsRemoved)
+    }
 }

--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -6,6 +6,7 @@ class Preferences: Codable {
         case removeSemicolons = "areSemicolonsRemoved"
     }
 
+    static var shared: Preferences?
     private static let sharedUserDefaults = {
         UserDefaults(suiteName: "com.jintin.swimat.configuration")!
     }()

--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -56,4 +56,5 @@ class Preferences: Codable {
         print(Key.parameterAlignment.rawValue, areParametersAligned)
         print(Key.removeSemicolons.rawValue, areSemicolonsRemoved)
     }
+
 }

--- a/Parser/Preferences.swift
+++ b/Parser/Preferences.swift
@@ -13,20 +13,20 @@ class Preferences: Codable {
 
     static var areParametersAligned: Bool {
         get {
-            return getBool(key: Key.parameterAlignment)
+            return getBool(key: .parameterAlignment)
         }
         set {
-            setBool(key: Key.parameterAlignment, value: newValue)
+            setBool(key: .parameterAlignment, value: newValue)
         }
     }
     var areParametersAligned: Bool
 
     static var areSemicolonsRemoved: Bool {
         get {
-            return getBool(key: Key.removeSemicolons)
+            return getBool(key: .removeSemicolons)
         }
         set {
-            setBool(key: Key.removeSemicolons, value: newValue)
+            setBool(key: .removeSemicolons, value: newValue)
         }
     }
     var areSemicolonsRemoved: Bool

--- a/Parser/SwiftParser.swift
+++ b/Parser/SwiftParser.swift
@@ -37,7 +37,7 @@ class SwiftParser {
     var isNextEnum: Bool = false
     var autoRemoveChar: Bool = false
 
-    init(string: String, preferences: Preferences? = nil) {
+    init(string: String, preferences: Preferences? = Options.shared.preference) {
         self.string = string
         self.strIndex = string.startIndex
 

--- a/Parser/SwiftParser.swift
+++ b/Parser/SwiftParser.swift
@@ -37,7 +37,7 @@ class SwiftParser {
     var isNextEnum: Bool = false
     var autoRemoveChar: Bool = false
 
-    init(string: String, preferences: Preferences? = Options.shared.preference) {
+    init(string: String, preferences: Preferences? = Preferences.shared) {
         self.string = string
         self.strIndex = string.startIndex
 


### PR DESCRIPTION
# Read the configuration from the file for CLI.
**Example:**
`swimat -c .swimat.json`
`swimat --config ./.config.swimat.json`

by default, the tool will use `.swimat.json` if exist

**config example** 
```json
{
    "areParametersAligned": true,
    "areSemicolonsRemoved": true
}
```

**Motivation**
- CLI tool can't read UserDefault settings that were set up via App
- Sometimes need settings per project with ignoring local settings for automation through the build phase 

