### PR TITLE
Homebrew 2.6.0 'brew cask' is deprecated, using 'brew --cask' instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ There are three way to install.
 1. Install via [homebrew-cask](https://caskroom.github.io/)
 
   ```bash
+  # Homebrew previous version
   brew cask install swimat
+  ```
+  ```bash
+  # Homebrew latest version
+  brew install --cask swimat
   ```
 
 2. Download the App directly.<br>


### PR DESCRIPTION
I just found out fail to install when I execute your way to install 'Swimat' in your README.md.
I am writting to tell you As of Homebrew 2.6.0 'brew cask' is deprecated, using 'brew --cask' instead so updated your README.md file!
I am appreciated for help me to use cool Xcode extension.
Thanks! :)